### PR TITLE
reworked plugins to allow norma and meteor to run side by side

### DIFF
--- a/Norma
+++ b/Norma
@@ -7,3 +7,8 @@ tasks:
       "junction": "NewSpring/junction-framework"
     "/packages":
       "meteor-scss": "https://github.com/NewSpring/meteor-scss.git#7c6b8aff8225dd5030a21d09f169d839f8693cf9"
+
+  "meteor-run":
+    endpoint: "jbaxleyiii/norma-meteor-run"
+    src: "./"
+    settings: "./.remote/settings/sites/rockrms.church/settings.json"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get up and running with Slingshot, run the following commands:
 
 ```bash
 $ norma build
-$ meteor
+$ norma
 
 ```
 

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ deployment:
   hub:
     branch: master
     commands:
-      # - cp ./.remote/settings/sites/rockrms.church/settings.json ./settings.json
+      - cp ./.remote/settings/sites/rockrms.church/settings.json ./settings.json
       - cp ./.remote/settings/sites/rockrms.church/mup.json ./mup.json
       - cp ./.remote/settings/sites/app.newspring.io/apollos.pem ./apollos.pem
       - cp ./.remote/settings/sites/app.newspring.io/compose.pem ./compose.pem

--- a/entry/client/webpack.conf.js
+++ b/entry/client/webpack.conf.js
@@ -10,9 +10,6 @@ if (process.env.NODE_ENV !== 'production') {
         transform: 'react-transform-hmr',
         imports: ['react'],
         locals: ['module']
-      }, {
-        transform: 'react-transform-catch-errors',
-        imports: ['react', 'redbox-react']
       }]
       // redbox-react is breaking the line numbers :-(
       // you might want to disable it
@@ -24,7 +21,12 @@ module.exports = {
   entry: './entry',
   module: {
     loaders: [
-      { test: /\.jsx?$/, loader: 'babel', query: babelSettings, exclude: /node_modules/ },
+      {
+        test: /\.jsx?$/,
+        loader: 'babel',
+        query: babelSettings,
+        exclude: /node_modules/
+      },
       { test: /\.css$/, loader: 'style!css' },
       { test: /\.(png|jpe?g)(\?.*)?$/, loader: 'url?limit=8182' },
       { test: /\.(svg|ttf|woff|eot)(\?.*)?$/, loader: 'file' }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,10 @@
   "bugs": {
     "url": "https://github.com/NewSpring/Slingshot/issues"
   },
-  "homepage": "https://github.com/NewSpring/Slingshot#readme"
+  "homepage": "https://github.com/NewSpring/Slingshot#readme",
+  "dependencies": {
+    "babel-plugin-react-transform": "^1.1.1",
+    "norma-bower": "^0.3.7",
+    "norma-meteor-run": "jbaxleyiii/norma-meteor-run"
+  }
 }

--- a/webpack.packages.json
+++ b/webpack.packages.json
@@ -11,6 +11,5 @@
 
   "babel-plugin-react-transform": "^1.1.1",
   "react-transform-hmr": "^1.0.1",
-  "react-transform-catch-errors": "^1.0.0",
-  "redbox-react": "^1.1.1"
+  "react-transform-catch-errors": "^1.0.0"
 }


### PR DESCRIPTION
This lets devs run `norma` to run meteor + settings injections
