### PR TITLE
[WIP] Add SSL API and Domain API

### DIFF
--- a/packages/azure/index.js
+++ b/packages/azure/index.js
@@ -6,7 +6,9 @@ if (!Meteor.settings.azure ||
     !Meteor.settings.azure.AZURE_TENANT_ID ||
     !Meteor.settings.azure.AZURE_SUBSCRIPTION_ID ||
     !Meteor.settings.azure.AZURE_DNS_RESOURCE_GROUP_NAME ||
-    !Meteor.settings.azure.AZURE_DNS_ZONE_NAME
+    !Meteor.settings.azure.AZURE_DNS_ZONE_NAME ||
+    !Meteor.settings.azure.AZURE_PFX_BLOB ||
+    !Meteor.settings.azure.AZURE_PFX_PASS
   ) {
 
     throw new Meteor.Error("Azure api credientials are missing");

--- a/packages/azure/index.js
+++ b/packages/azure/index.js
@@ -7,8 +7,8 @@ if (!Meteor.settings.azure ||
     !Meteor.settings.azure.AZURE_SUBSCRIPTION_ID ||
     !Meteor.settings.azure.AZURE_DNS_RESOURCE_GROUP_NAME ||
     !Meteor.settings.azure.AZURE_DNS_ZONE_NAME ||
-    !Meteor.settings.azure.AZURE_PFX_BLOB ||
-    !Meteor.settings.azure.AZURE_PFX_PASS
+    !Meteor.settings.ssl.cert ||
+    !Meteor.settings.ssl.password
   ) {
 
     throw new Meteor.Error("Azure api credientials are missing");

--- a/packages/azure/lib/cert.js
+++ b/packages/azure/lib/cert.js
@@ -64,3 +64,68 @@ Azure.cert.add = (resourceGroupName, cb) => {
   });
 
 };
+
+// make sure to save thumbprint from Azure.cert.add call
+Azure.cert.assign = (resourceGroupName, cname, thumbprint, cb) => {
+  check(resourceGroupName, String);
+  check(cb, Function);
+
+  Azure.token.get((err, result) => {
+    const token = result.accessToken;
+
+    if (err) {
+      throw new Meteor.Error(`Unable to authenticate: ${err.stack}`);
+    }
+
+    const path = [
+      "/subscriptions/",
+      subscriptionId,
+      "/resourceGroups/",
+      resourceGroupName,
+      "/providers/Microsoft.Web/sites/",
+      resourceGroupName,
+      "?api-version=2014-11-01"
+    ];
+
+    const headers = [
+      { "Content-Type": "application/json" },
+      { "Authorization": `Bearer ${token}` }
+    ];
+
+    const body = querystring.stringify({
+      "name": resourceGroupName,
+      "type": "Microsoft.Web/sites",
+      "location": "East US",
+      "properties": {
+        "hostNameSslStates": [
+          {
+            "name": `${cname}.rockrms.church`,
+            "sslSate": 1,
+            "thumbprint": thumbprint,
+            "toUpdate": 1
+          }
+        ]
+      }
+    });
+
+    const options = {
+      host: resourceURI,
+      path: path,
+      method: "PUT",
+      headers: headers
+    };
+
+    const req = https.request(options, (res) => {
+      cb(res);
+    });
+
+    req.on("error", (err) => {
+      console.log(`Error: ${err.message}`);
+    });
+
+    req.write(body);
+    req.end();
+
+  });
+
+};

--- a/packages/azure/lib/cert.js
+++ b/packages/azure/lib/cert.js
@@ -3,8 +3,8 @@ const https = Npm.require("https"),
 
 const resourceURI = "management.azure.com",
       subscriptionId = Meteor.settings.azure.AZURE_SUBSCRIPTION_ID,
-      pfxBlob = Meteor.settings.azure.AZURE_PFX_BLOB,
-      pfxPass = Meteor.settings.azure.AZURE_PFX_PASS
+      pfxBlob = Meteor.settings.ssl.cert,
+      pfxPass = Meteor.settings.ssl.pass
 
 Azure.cert = {};
 

--- a/packages/azure/lib/cert.js
+++ b/packages/azure/lib/cert.js
@@ -1,0 +1,66 @@
+const https = Npm.require("https"),
+      querystring = Npm.require("querystring");
+
+const resourceURI = "management.azure.com",
+      subscriptionId = Meteor.settings.azure.AZURE_SUBSCRIPTION_ID,
+      pfxBlob = Meteor.settings.azure.AZURE_PFX_BLOB,
+      pfxPass = Meteor.settings.azure.AZURE_PFX_PASS
+
+Azure.cert = {};
+
+Azure.cert.add = (resourceGroupName, cb) => {
+  check(resourceGroupName, String);
+
+  Azure.token.get((err, result) => {
+    const token = result.accessToken;
+
+    if (err) {
+      throw new Meteor.Error(`Unable to authenticate: ${err.stack}`);
+    }
+
+    const path = [
+      "/subscriptions/",
+      subscriptionId,
+      "/resourceGroups/",
+      resourceGroupName,
+      "/providers/Microsoft.Web/certificates/",
+      resourceGroupName,
+      "?api-version=2014-11-01"
+    ].join("");
+
+    const headers = [
+      { "Content-Type": "application/json" },
+      { "Authorization": `Bearer ${token}` }
+    ];
+
+    const body = querystring.stringify({
+      "name": resourceGroupName,
+      "type": "Microsoft.Web/certificates",
+      "location": "East US",
+      "properties": {
+        "pfxBlob": pfxBlob,
+        "password": pfxPass
+      }
+    });
+
+    const options = {
+      host: resourceURI,
+      path: path,
+      method: "PUT",
+      headers: headers
+    };
+
+    const req = https.request(options, (res) => {
+      cb(res);
+    });
+
+    req.on("error", (err) => {
+      console.log(`Error: ${err.message}`);
+    });
+
+    req.write(body);
+    req.end();
+
+  });
+
+};

--- a/packages/azure/lib/cname.js
+++ b/packages/azure/lib/cname.js
@@ -10,6 +10,7 @@ Azure.cname = {};
 Azure.cname.create = (cname, url, cb) => {
   check(cname, String);
   check(url, String);
+  check(cb, Function);
 
   Azure.token.get((err, result) => {
 

--- a/packages/azure/package.js
+++ b/packages/azure/package.js
@@ -20,6 +20,7 @@ Package.onUse(function (api) {
   api.addFiles('lib/cname.js', 'server');
   api.addFiles('lib/resourceGroup.js', 'server');
   api.addFiles('lib/deployment.js', 'server');
+  api.addFiles('lib/cert.js', 'server');
 
   api.export('Azure', 'server');
 });

--- a/packages/azure/package.js
+++ b/packages/azure/package.js
@@ -21,6 +21,7 @@ Package.onUse(function (api) {
   api.addFiles('lib/resourceGroup.js', 'server');
   api.addFiles('lib/deployment.js', 'server');
   api.addFiles('lib/cert.js', 'server');
+  api.addFiles('lib/domain.js', 'server');
 
   api.export('Azure', 'server');
 });


### PR DESCRIPTION
This will add SSL and Domain automation to the Azure package when it is done.
- [x] Add cert to resource group
- [x] _sort of_ Assign cert to domain
- [ ] Assign domain to web app

Adding the cert to the resource group is working great.

Assigning the cert to the domain is returning true, looking great, and not working.

I thought I had the API call for assigning a domain to a web app worked out. I do not. I can't find anything on it. It's gotta be right under my nose.
